### PR TITLE
feat(DEV-311): generate switch config locally

### DIFF
--- a/roles/os6_aaa/README.md
+++ b/roles/os6_aaa/README.md
@@ -10,6 +10,7 @@ Role variables
 
 - Role is abstracted using the `ansible_network_os` variable that can take `dellemc.os6.os6` as the value
 - If `os6_cfg_generate` is set to true, the variable generates the role configuration commands in a file
+- If `os6_cfg_deploy` is set to true, the variable deploys the role configuration commands to the ansible_host
 - Any role variable with a corresponding state variable set to absent negates the configuration of that variable
 - Setting an empty value for any variable negates the corresponding configuration
 - Variables and values are case-sensitive

--- a/roles/os6_aaa/tasks/main.yml
+++ b/roles/os6_aaa/tasks/main.yml
@@ -5,13 +5,13 @@
    template:
       src: os6_aaa.j2
       dest: "{{ build_dir }}/aaa6_{{ hostname }}.conf.part"
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_generate | default('False')) | bool)
+   when: ((os6_cfg_generate | default('False')) | bool)
 #   notify: save config os6
    register: generate_output
 
  - name: "Provisioning AAA configuration for os6"
    dellemc.os6.os6_config:
       src: os6_aaa.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_deploy | default('True')) | bool)
 #   notify: save config os6
    register: output

--- a/roles/os6_acl/README.md
+++ b/roles/os6_acl/README.md
@@ -11,6 +11,7 @@ Role variables
 
 - Role is abstracted using the `ansible_network_os` variable that can take `dellemc.os6.os6` as a value
 - If `os6_cfg_generate` is set to true, the variable generates the role configuration commands in a file
+- If `os6_cfg_deploy` is set to true, the variable deploys the role configuration commands to the ansible_host
 - Any role variable with a corresponding state variable set to absent negates the configuration of that variable
 - Setting an empty value for any variable negates the corresponding configuration
 - Variables and values are case-sensitive

--- a/roles/os6_acl/tasks/main.yml
+++ b/roles/os6_acl/tasks/main.yml
@@ -5,13 +5,13 @@
    template:
       src: os6_acl.j2
       dest: "{{ build_dir }}/acl6_{{ hostname }}.conf.part"
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_generate | default('False')) | bool)
+   when: ((os6_cfg_generate | default('False')) | bool)
 #   notify: save config os6
    register: generate_output
 
  - name: "Provisioning ACL configuration for os6"
    dellemc.os6.os6_config:
       src: os6_acl.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_deploy | default('True')) | bool)
 #   notify: save config os6
    register: output

--- a/roles/os6_bgp/README.md
+++ b/roles/os6_bgp/README.md
@@ -11,6 +11,7 @@ Role variables
  
 - Role is abstracted using the `ansible_network_os` variable that can take `dellemc.os6.os6` as a value
 - If variable `os6_cfg_generate` is set to true, it generates the role configuration commands in a file
+- If `os6_cfg_deploy` is set to true, the variable deploys the role configuration commands to the ansible_host
 - Any role variable with a corresponding state variable setting to absent negates the configuration of that variable
 - Setting an empty value for any variable negates the corresponding configuration
 - Variables and values are case-sensitive

--- a/roles/os6_bgp/tasks/main.yml
+++ b/roles/os6_bgp/tasks/main.yml
@@ -5,13 +5,13 @@
    template:
       src: os6_bgp.j2
       dest: "{{ build_dir }}/bgp6_{{ hostname }}.conf.part"
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_generate | default('False')) | bool)
+   when: ((os6_cfg_generate | default('False')) | bool)
 #   notify: save config os6
    register: generate_output
 
  - name: "Provisioning BGP configuration for os6"
    dellemc.os6.os6_config:
       src: os6_bgp.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_deploy | default('True')) | bool)
 #   notify: save config os6
    register: output

--- a/roles/os6_interface/README.md
+++ b/roles/os6_interface/README.md
@@ -11,6 +11,7 @@ Role variables
 
 - Role is abstracted using the `ansible_network_os` variable that can take `dellemc.os6.os6` as a value
 - If `os6_cfg_generate` is set to true, the variable generates the role configuration commands in a file
+- If `os6_cfg_deploy` is set to true, the variable deploys the role configuration commands to the ansible_host
 - Any role variable with a corresponding state variable setting to absent negates the configuration of that variable
 - Setting an empty value for any variable negates the corresponding configuration
 - `os6_interface` (dictionary) holds a dictionary with the interface name; interface name can correspond to any of the valid OS interfaces with the unique interface identifier name

--- a/roles/os6_interface/tasks/main.yml
+++ b/roles/os6_interface/tasks/main.yml
@@ -5,13 +5,13 @@
    template:
       src: os6_interface.j2
       dest: "{{ build_dir }}/intf6_{{ hostname }}.conf.part"
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_generate | default('False')) | bool)
+   when: ((os6_cfg_generate | default('False')) | bool)
 #   notify: save config os6
    register: generate_output
 
  - name: "Provisioning interface configuration for os6"
    dellemc.os6.os6_config:
       src: os6_interface.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_deploy | default('True')) | bool)
 #   notify: save config os6
    register: output

--- a/roles/os6_lag/README.md
+++ b/roles/os6_lag/README.md
@@ -13,6 +13,8 @@ Role variables
 - Object drives the tasks in this role
 - `os6_lag` (dictionary) contains the hostname (dictionary)
 - Hostname is the value of the *hostname* variable that corresponds to the name of the OS device
+- If `os6_cfg_generate` is set to true, the variable generates the role configuration commands in a file
+- If `os6_cfg_deploy` is set to true, the variable deploys the role configuration commands to the ansible_host
 - Any role variable with a corresponding state variable setting to absent negates the configuration of that variable
 - Setting an empty value to any variable negates the corresponding configuration
 - `os6_lag` (dictionary) holds a dictionary with the port-channel ID key in `Po <ID>` format (1 to 128 for os6)

--- a/roles/os6_lag/tasks/main.yml
+++ b/roles/os6_lag/tasks/main.yml
@@ -5,13 +5,13 @@
    template:
       src: os6_lag.j2
       dest: "{{ build_dir }}/lag6_{{ hostname }}.conf.part"
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_generate | default('False')) | bool)
+   when: ((os6_cfg_generate | default('False')) | bool)
 #   notify: save config os6
    register: generate_output
 
  - name: "Provisioning LAG configuration for os6"
    dellemc.os6.os6_config:
       src: os6_lag.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_deploy | default('True')) | bool)
 #   notify: save config os6
    register: output

--- a/roles/os6_lldp/README.md
+++ b/roles/os6_lldp/README.md
@@ -9,6 +9,7 @@ Role variables
 --------------
 
 - If `os6_cfg_generate` is set to true, the variable generates the role configuration commands in a file
+- If `os6_cfg_deploy` is set to true, the variable deploys the role configuration commands to the ansible_host
 - Any role variable with a corresponding state variable set to absent negates the configuration of that variable
 - Setting an empty value for any variable negates the corresponding configuration
 - Variables and values are case-sensitive

--- a/roles/os6_lldp/tasks/main.yml
+++ b/roles/os6_lldp/tasks/main.yml
@@ -5,13 +5,13 @@
    template:
       src: os6_lldp.j2
       dest: "{{ build_dir }}/lldp6_{{ hostname }}.conf.part"
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_generate | default('False')) | bool)
+   when: ((os6_cfg_generate | default('False')) | bool)
 #   notify: save config os6
    register: generate_output
 
  - name: "Provisioning LLDP configuration for os6"
    dellemc.os6.os6_config:
       src: os6_lldp.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_deploy | default('True')) | bool)
 #   notify: save config os6
    register: output

--- a/roles/os6_logging/README.md
+++ b/roles/os6_logging/README.md
@@ -10,7 +10,8 @@ Role variables
 --------------
 
 - Role is abstracted using the `ansible_network_os` variable that can take `dellemc.os6.os6` as a value
-- If the `os6_cfg_generate` variable is set to true, it generates the role configuration commands in a file
+- If `os6_cfg_generate` is set to true, the variable generates the role configuration commands in a file
+- If `os6_cfg_deploy` is set to true, the variable deploys the role configuration commands to the ansible_host
 - Any role variable with a corresponding state variable set to absent negates the configuration of that variable
 - Setting an empty value for any variable negates the corresponding configuration
 -  Variables and values are case-sensitive

--- a/roles/os6_logging/tasks/main.yml
+++ b/roles/os6_logging/tasks/main.yml
@@ -5,13 +5,13 @@
    template:
       src: os6_logging.j2
       dest: "{{ build_dir }}/logging6_{{ hostname }}.conf.part"
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_generate | default('False')) | bool)
+   when: ((os6_cfg_generate | default('False')) | bool)
 #   notify: save config os6
    register: generate_output
 
  - name: "Provisioning logging configuration for os6"
    dellemc.os6.os6_config:
       src: os6_logging.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_deploy | default('True')) | bool)
 #   notify: save config os6
    register: output

--- a/roles/os6_ntp/README.md
+++ b/roles/os6_ntp/README.md
@@ -10,6 +10,7 @@ Role variables
 
 - Role is abstracted using the `ansible_network_os` variable that can take `dellemc.os6.os6` as a value
 - If `os6_cfg_generate` is set to true, the variable generates the role configuration commands in a file
+- If `os6_cfg_deploy` is set to true, the variable deploys the role configuration commands to the ansible_host
 - Any role variable with a corresponding state variable set to absent negates the configuration of that variable
 - Setting an empty value for any variable negates the corresponding configuration
 - Variables and values are case-sensitive

--- a/roles/os6_ntp/tasks/main.yml
+++ b/roles/os6_ntp/tasks/main.yml
@@ -5,13 +5,13 @@
    template:
       src: os6_ntp.j2
       dest: "{{ build_dir }}/ntp6_{{ hostname }}.conf.part"
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_generate | default('False'))| bool)
+   when: ((os6_cfg_generate | default('False'))| bool)
 #   notify: save config os6
    register: generate_output
 
  - name: "Provisioning NTP configuration for os6"
    dellemc.os6.os6_config:
       src: os6_ntp.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_deploy | default('True')) | bool)
 #   notify: save config os6
    register: output

--- a/roles/os6_qos/README.md
+++ b/roles/os6_qos/README.md
@@ -11,6 +11,7 @@ Role variables
 
 - Role is abstracted using the `ansible_network_os` variable that can take a `dellemc.os6.os6` as a value
 - If `os6_cfg_generate` is set to true, the variable generates the role configuration commands in a file
+- If `os6_cfg_deploy` is set to true, the variable deploys the role configuration commands to the ansible_host
 - Any role variable with a corresponding state variable set to absent negates the configuration of that variable 
 - Setting an empty value for any variable negates the corresponding configuration
 - Variables and values are case-sensitive

--- a/roles/os6_qos/tasks/main.yml
+++ b/roles/os6_qos/tasks/main.yml
@@ -4,7 +4,7 @@
  - name: "Provisioning Qos configuration for os6"
    dellemc.os6.os6_config:
       src: os6_qos.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_deploy | default('True')) | bool)
 #   notify: save config os6
    register: output
 
@@ -12,6 +12,6 @@
    template:
       src: os6_qos.j2
       dest: "{{ build_dir }}/qos6_{{ hostname }}.conf.part"
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_generate | default('False')) | bool)
+   when: ((os6_cfg_generate | default('False')) | bool)
 #   notify: save config os6
    register: generate_output

--- a/roles/os6_snmp/README.md
+++ b/roles/os6_snmp/README.md
@@ -11,6 +11,7 @@ Role variables
 
 - Role is abstracted using the `ansible_network_os` variable that can take `dellemc.os6.os6` as a value
 - If `os6_cfg_generate` is set to true, the variable generates the role configuration commands in a file
+- If `os6_cfg_deploy` is set to true, the variable deploys the role configuration commands to the ansible_host
 - Any role variable with a corresponding state variable set to absent negates the configuration of that variable
 - Setting an empty value for any variable negates the corresponding configuration
 - Variables and values are case-sensitive

--- a/roles/os6_snmp/tasks/main.yml
+++ b/roles/os6_snmp/tasks/main.yml
@@ -5,19 +5,20 @@
    os6_command:
      commands:
        - "show running-config | include \"snmp-server community\""
+   when:  ((os6_cfg_deploy | default('True')) | bool)
    register: snmp_communities
-    
+
  - name: "Generating SNMP configuration for os6"
    template:
       src: os6_snmp.j2
       dest: "{{ build_dir }}/snmp6_{{ hostname }}.conf.part"
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_generate | default('False')) | bool)
+   when: ((os6_cfg_generate | default('False')) | bool)
 #   notify: save config os6
    register: generate_output
 
  - name: "Provisioning SNMP configuration for os6"
    dellemc.os6.os6_config:
       src: os6_snmp.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_deploy | default('True')) | bool)
 #   notify: save config os6
    register: output

--- a/roles/os6_snmp/templates/os6_snmp.j2
+++ b/roles/os6_snmp/templates/os6_snmp.j2
@@ -42,7 +42,7 @@ no snmp-server location
   {% elif key == "snmp_community" %}
     {% if value %}
       {% for item in value %}
-        {% if item.name is defined and item.name %}
+        {% if item.name is defined and item.name and snmp_communities.stdout is defined and snmp_communities.stdout %}
           {% for exists in snmp_communities.stdout %}
             {% if item.state is defined and item.name in exists and item.state == "absent" %}
 no snmp-server community {{ item.name }}

--- a/roles/os6_system/README.md
+++ b/roles/os6_system/README.md
@@ -10,6 +10,7 @@ Role variables
 
 - Role is abstracted using the `ansible_network_os` variable that can take `dellemc.os6.os6` as a value
 - If `os6_cfg_generate` is set to true, the variable generates the role configuration commands in a file
+- If `os6_cfg_deploy` is set to true, the variable deploys the role configuration commands to the ansible_host
 - Any role variable with a corresponding state variable set to absent negates the configuration of that variable
 - Setting an empty value for any variable negates the corresponding configuration
 - Variables and values are case-sensitive

--- a/roles/os6_system/tasks/main.yml
+++ b/roles/os6_system/tasks/main.yml
@@ -5,13 +5,13 @@
    template:
       src: os6_system.j2
       dest: "{{ build_dir }}/system6_{{ hostname }}.conf.part"
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_generate | default('False')) | bool)
+   when: ((os6_cfg_generate | default('False')) | bool)
 #   notify: save config os6
    register: generate_output
 
  - name: "Provisioning system configuration for os6"
    dellemc.os6.os6_config:
       src: os6_system.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_deploy | default('True')) | bool)
 #   notify: save config os6
    register: output

--- a/roles/os6_users/README.md
+++ b/roles/os6_users/README.md
@@ -11,6 +11,7 @@ Role variables
 
 - Role is abstracted using the `ansible_network_os` variable that can take `dellemc.os6.os6` as a value
 - If `os6_cfg_generate` is set to true, the variable generates the role configuration commands in a file
+- If `os6_cfg_deploy` is set to true, the variable deploys the role configuration commands to the ansible_host
 - Any role variable with a corresponding state variable set to absent negates the configuration of that variable
 - Setting an empty value for any variable negates the corresponding configuration
 - Variables and values are case-sensitive

--- a/roles/os6_users/tasks/main.yml
+++ b/roles/os6_users/tasks/main.yml
@@ -5,13 +5,13 @@
    template:
       src: os6_users.j2
       dest: "{{ build_dir }}/users6_{{ hostname }}.conf.part"
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_generate | default('False')) | bool)
+   when: ((os6_cfg_generate | default('False')) | bool)
 #   notify: save config os6
    register: generate_output
 
  - name: "Provisioning users configuration for os6"
    dellemc.os6.os6_config:
       src: os6_users.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_deploy | default('True')) | bool)
 #   notify: save config os6
    register: output

--- a/roles/os6_vlan/README.md
+++ b/roles/os6_vlan/README.md
@@ -11,6 +11,7 @@ Role variables
 
 - Role is abstracted using the `ansible_network_os` variable that can take `dellemc.os6.os6` as a value 
 - If `os6_cfg_generate` is set to true, the variable generates the role configuration commands in a file
+- If `os6_cfg_deploy` is set to true, the variable deploys the role configuration commands to the ansible_host
 - Any role variable with a corresponding state variable set to absent negates the configuration of that variable
 - For variables with no state variable, setting an empty value for the variable negates the corresponding configuration
 - `os6_vlan` (dictionary) holds the key with the VLAN ID key and default-vlan key.

--- a/roles/os6_vlan/tasks/main.yml
+++ b/roles/os6_vlan/tasks/main.yml
@@ -5,13 +5,13 @@
    template:
       src: os6_vlan.j2
       dest: "{{ build_dir }}/vlan6_{{ hostname }}.conf.part"
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_generate | default('False')) | bool)
+   when: ((os6_cfg_generate | default('False')) | bool)
 #   notify: save config os6
    register: generate_output
 
  - name: "Provisioning VLAN configuration for os6"
    dellemc.os6.os6_config:
       src: os6_vlan.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_deploy | default('True')) | bool)
 #   notify: save config os6
    register: output

--- a/roles/os6_vrrp/README.md
+++ b/roles/os6_vrrp/README.md
@@ -10,6 +10,7 @@ Role variables
 
 - Role is abstracted using the `ansible_network_os` variable that can take `dellemc.os6.os6` as a value
 - If `os6_cfg_generate` is set to true, the variable generates the role configuration commands in a file
+- If `os6_cfg_deploy` is set to true, the variable deploys the role configuration commands to the ansible_host
 - Any role variable with a corresponding state variable set to absent negates the configuration of that variable
 - Setting an empty value for any variable negates the corresponding configuration
 - `os6_vrrp` (dictionary) holds a dictionary with the interface name key

--- a/roles/os6_vrrp/tasks/main.yml
+++ b/roles/os6_vrrp/tasks/main.yml
@@ -4,13 +4,13 @@
    template:
       src: os6_vrrp.j2
       dest: "{{ build_dir }}/vrrp6_{{ hostname }}.conf.part"
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_generate | default('False'))| bool)
+   when: ((os6_cfg_generate | default('False'))| bool)
 #   notify: save config os6
    register: generate_output
 
  - name: "Provisioning VRRP configuration for os6"
    dellemc.os6.os6_config:
       src: os6_vrrp.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_deploy | default('True')) | bool)
 #   notify: save config os6
    register: output

--- a/roles/os6_xstp/README.md
+++ b/roles/os6_xstp/README.md
@@ -9,6 +9,8 @@ Role variables
 --------------
 
 - Role is abstracted using the `ansible_network_os` variable that can take `dellemc.os6.os6` as a value
+- If `os6_cfg_generate` is set to true, the variable generates the role configuration commands in a file
+- If `os6_cfg_deploy` is set to true, the variable deploys the role configuration commands to the ansible_host
 - `os6_xstp` (dictionary) contains the hostname (dictionary)
 - Hostname is the value of the *hostname* variable that corresponds to the name of the OS device
 - Any role variable with a corresponding state variable set to absent negates the configuration of that variable

--- a/roles/os6_xstp/tasks/main.yml
+++ b/roles/os6_xstp/tasks/main.yml
@@ -5,13 +5,13 @@
    template:
       src: os6_xstp.j2
       dest: "{{ build_dir }}/xstp6_{{ hostname }}.conf.part"
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_generate | default('False')) | bool)
+   when: ((os6_cfg_generate | default('False')) | bool)
 #   notify: save config os6
    register: generate_output
 
  - name: "Provisioning xSTP configuration for os6"
    dellemc.os6.os6_config:
       src: os6_xstp.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os6.os6") and ((os6_cfg_deploy | default('True')) | bool)
 #   notify: save config os6
    register: output


### PR DESCRIPTION
add option to generate config into a text file for each module locally, without deploying or even connecting to a switch.  also update documentation to reflect this addition